### PR TITLE
fix: dryr-run command and environment names containing digits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ list: ## make list # List infra resources
 	@bash terraform.sh show $(opts)
 
 .PHONY: dry-run
-dry-run: pass ## make dry-run # Dry run resources changes
+dry-run: ## make dry-run # Dry run resources changes
 	@bash terraform.sh plan $(opts)
 
 .PHONY: run

--- a/terraform.sh
+++ b/terraform.sh
@@ -12,7 +12,7 @@
 
 valid_identifier()
 {
-    echo "$1" | tr '[:lower:]' '[:upper:]' | tr -cs '[:alpha:]\n' '_'
+    echo "$1" | tr '[:lower:]' '[:upper:]' | tr -cs '[:alpha:][:digit:]\n' '_'
 }
 
 key="$(valid_identifier "${provider}")_$(valid_identifier "${env}")_KEY"


### PR DESCRIPTION
@mvisonneau could you review please?
