### PR TITLE
docker: fixing tf-make binary within the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM hashicorp/terraform:0.10.7
 
 RUN \
 apk add --no-cache make bash ;\
-echo 'tf-make() { make -f /opt/terraform/Makefile $@ ; }' >> /etc/profile
+echo -e "#"'!'"/usr/bin/env bash\n\nmake -f /opt/terraform/Makefile $@" > /usr/bin/tf-make ;\
+chmod +x /usr/bin/tf-make
 
 WORKDIR /opt/terraform
 COPY . .
@@ -10,4 +11,4 @@ COPY . .
 VOLUME [ /opt/terraform/providers ]
 VOLUME [ /opt/terraform/modules ]
 
-ENTRYPOINT [ "/bin/bash", "-l" ]
+ENTRYPOINT [ "/usr/bin/tf-make" ]


### PR DESCRIPTION
This one is the good one @mvisonneau 

```
> docker run --rm -ti --entrypoint "" swcc/terraform-makefile /bin/sh  -c 'tf-make'
Terraform-makefile v0.10.7
[...]
```