### PR TITLE
Added missing build libraries for latest version of landscape

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM hashicorp/terraform:0.11.10
 
 RUN \
 apk add --no-cache make bash ca-certificates jq curl ruby ruby-json;\
+apk add --no-cache -t build gcc ruby-dev libc-dev ;\
 echo -e "#"'!'"/usr/bin/env bash\n\nmake -f /opt/terraform/Makefile "'$'"@" > /usr/bin/tf-make ;\
 chmod +x /usr/bin/tf-make ;\
-gem install --no-rdoc --no-ri terraform_landscape
+gem install --no-rdoc --no-ri terraform_landscape ;\
+apk del --purge build
 
 WORKDIR /opt/terraform
 ADD . .


### PR DESCRIPTION
Docker image doesn't build since the latest release of terraform-landscape gem :( :
- https://rubygems.org/gems/terraform_landscape
- https://hub.docker.com/r/swcc/terraform-makefile/builds/bcpv3tpdksaoitj8d63sy7y/