### PR TITLE
Makefile: allow passing args to tf-make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ ifeq ($(install),"true")
 	@unzip -d /usr/bin /usr/bin/terraform.zip && rm /usr/bin/terraform.zip
 endif
 	@terraform --version
-	@bash $(dir $(mkfile_path))/terraform.sh init
+	@bash $(dir $(mkfile_path))/terraform.sh init $(args)
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
I see no reason arguments can't be passed for `tf-make install` :-)